### PR TITLE
Update faraday

### DIFF
--- a/circleci-coverage_reporter.gemspec
+++ b/circleci-coverage_reporter.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency 'faraday', '>= 0.9' , '< 2.0.0'
   spec.add_development_dependency 'bundler', '~> 1.12'
 end

--- a/spec/support/sandboxing.rb
+++ b/spec/support/sandboxing.rb
@@ -1,4 +1,5 @@
 require 'circleci/coverage_reporter/sandbox'
+require 'tmpdir'
 
 RSpec.configure do |c|
   c.around do |example|


### PR DESCRIPTION
Faraday 1.0以降でも利用できるようにした。
対応gemバージョンを上げる以外特に必要なさそうだが、rspecが落ちていたのでついでに修正した。